### PR TITLE
Prevent undefined method errors when include is provided

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -340,7 +340,9 @@ module FastJsonapi
         return if includes.blank?
 
         parse_includes_list(includes).each_key do |include_item|
-          relationship_to_include = relationships_to_serialize[include_item]
+          relationships = relationships_to_serialize || {}
+          relationship_to_include = relationships[include_item]
+
           raise(JSONAPI::Serializer::UnsupportedIncludeError.new(include_item, name)) unless relationship_to_include
 
           relationship_to_include.static_serializer # called for a side-effect to check for a known serializer class.

--- a/spec/integration/errors_spec.rb
+++ b/spec/integration/errors_spec.rb
@@ -21,5 +21,16 @@ RSpec.describe JSONAPI::Serializer do
           JSONAPI::Serializer::UnsupportedIncludeError, /bad_include is not specified as a relationship/
         )
     end
+
+    context 'when include is provided for a resource that does not have relationships' do
+      let(:user) { User.fake }
+
+      it do
+        expect { UserSerializer.new(user, include: ['bad_include']) }
+          .to raise_error(
+            JSONAPI::Serializer::UnsupportedIncludeError, /bad_include is not specified as a relationship/
+          )
+      end
+    end
   end
 end


### PR DESCRIPTION
## What?
- Default to an empty hash when fetching relationships for a serializer class that does not have any relationships defined.

## Why?
Previously, if `include` is passed in as argument for a serializer that does not have relationships defined, then a: `undefined method [] for nil:NilClass` is raised rather than the expected `JSONAPI::Serializer::UnsupportedIncludeError`. This was because `Serializer#relationships_to_serialize` was returning `nil`.

## What is the current behavior?
When `include` is provided as an argument for a serializer that does not have any relationships defined, then an `undefined method [] for nil:NilClass` error is raised instead of the expected: `JSONAPI::Serializer::UnsupportedIncludeError`.
```ruby
u = User.fake
UserSerializer.new(user, include: ['bad_include']) # => <NoMethodError: undefined method `[]' for nil:NilClass>
```

## What is the new behavior?
When `include` is provided as an argument for a serializer that does not have any relationships defined, then `JSONAPI::Serializer::UnsupportedIncludeError` is returned:
```ruby
u = User.fake
UserSerializer.new(user, include: ['bad_include']) # => <JSONAPI::Serializer::UnsupportedIncludeError>
```

## Notes
We've forked this repo, so that we can use the fix in: https://github.com/thrivadev/jsonapi-serializer/pull/1, while we wait for https://github.com/jsonapi-serializer/jsonapi-serializer/pull/236 being merged.